### PR TITLE
Added Exception for ScanForStorageMediaImage to allow for Logical Volume Scan

### DIFF
--- a/dfvfs/helpers/source_scanner.py
+++ b/dfvfs/helpers/source_scanner.py
@@ -368,7 +368,14 @@ class SourceScanner(object):
         scan_context.SetSourceType(definitions.SOURCE_TYPE_DIRECTORY)
         return
 
-      source_path_spec = self.ScanForStorageMediaImage(scan_node.path_spec)
+      try:
+        source_path_spec = self.ScanForStorageMediaImage(scan_node.path_spec)
+      except IOError:
+        # ScanForStorageMediaImage will error out from pysigscan_scanner_scan_file_object
+        # if SourceScannerContext is set to logical volume (example: \\.\C:), but we need to continue
+        # if it is a logical volume.
+        source_path_spec = None
+        
       if source_path_spec:
         scan_node.scanned = True
         scan_node = scan_context.AddScanNode(source_path_spec, scan_node)


### PR DESCRIPTION
If the source_path_spec for SourceScannerContext is set to a Windows Logical Volume (\\.\C:) IOError is thrown in pysigscan_scanner_scan_file_object. Adding the IOError exception allows the scanner to continue on and search for volumes. While this fixes the issue of a Windows Logical Volume not being properly scanned, not sure if it is the best place. Maybe better to add a new definition for something like SOURCE_TYPE_STORAGE_LOGICAL_VOLUME for GetStorageMediaImageTypeIndicators and an algorithm to detect the Logical Volume instead of catching an exception? 
