### PR TITLE
329870043: Changed to setup.py to exclude non-script files from bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,23 @@ else:
           in_description = True
 
         elif line.startswith('%files'):
-          line = '%files -f INSTALLED_FILES -n {0:s}-%{{name}}'.format(
-              python_package)
+          # Cannot use %{_libdir} here since it can expand to "lib64".
+          lines = [
+              '%files',
+              '%defattr(644,root,root,755)',
+              '%doc ACKNOWLEDGEMENTS AUTHORS LICENSE README',
+              '%{_prefix}/lib/python*/site-packages/dfvfs/*.py',
+              '%{_prefix}/lib/python*/site-packages/dfvfs/*/*.py',
+              '%{_prefix}/lib/python*/site-packages/dfvfs*.egg-info/*',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/*.pyc',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/*.pyo',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/__pycache__/*',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/*/*.pyc',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/*/*.pyo',
+              '%exclude %{_prefix}/lib/python*/site-packages/dfvfs/*/__pycache__/*']
+
+          python_spec_file.extend(lines)
+          break
 
         elif line.startswith('%prep'):
           in_description = False


### PR DESCRIPTION
[Code review: 329870043: Changed to setup.py to exclude non-script files from bdist_rpm](https://codereview.appspot.com/329870043/)