### PR TITLE
fast forward seeks on compressed streams

### DIFF
--- a/dfvfs/file_io/compressed_stream_io.py
+++ b/dfvfs/file_io/compressed_stream_io.py
@@ -117,9 +117,8 @@ class CompressedStream(file_io.FileIO):
         buffer_start_offset = (
             self._uncompressed_stream_position - self._uncompressed_data_size
         )
-
-        # if we don't have a decompressor we need one, or if we need to seek backwards
-        # we need a new decompressor
+        # If there is no decompressor or there was a backwards a new decompressor is
+        # needed.
         if self._decompressor is None or uncompressed_data_offset < buffer_start_offset:
             self._file_object.seek(0, os.SEEK_SET)
             self._decompressor = self._GetDecompressor()
@@ -130,13 +129,13 @@ class CompressedStream(file_io.FileIO):
             self._uncompressed_stream_position = 0
             buffer_start_offset = 0
 
-        # decompress forward
         while uncompressed_data_offset >= self._uncompressed_stream_position:
             read_count = self._ReadCompressedData(self._COMPRESSED_DATA_BUFFER_SIZE)
             if read_count == 0:
                 # End of the compressed stream before the target offset.
                 self._uncompressed_data_offset = self._uncompressed_data_size
                 return
+
             buffer_start_offset = (
                 self._uncompressed_stream_position - self._uncompressed_data_size
             )
@@ -161,7 +160,6 @@ class CompressedStream(file_io.FileIO):
         self._uncompressed_data, self._compressed_data = self._decompressor.Decompress(
             self._compressed_data
         )
-
         self._uncompressed_data_size = len(self._uncompressed_data)
 
         self._uncompressed_stream_position += self._uncompressed_data_size

--- a/dfvfs/file_io/compressed_stream_io.py
+++ b/dfvfs/file_io/compressed_stream_io.py
@@ -31,8 +31,8 @@ class CompressedStream(file_io.FileIO):
         self._uncompressed_data = b""
         self._uncompressed_data_offset = 0
         self._uncompressed_data_size = 0
+        self._uncompressed_stream_offset = 0
         self._uncompressed_stream_size = None
-        self._uncompressed_stream_position = 0
 
     def _Close(self):
         """Closes the file-like object.
@@ -68,7 +68,7 @@ class CompressedStream(file_io.FileIO):
         self._uncompressed_data = b""
         self._uncompressed_data_size = 0
         self._uncompressed_data_offset = 0
-        self._uncompressed_stream_position = 0
+        self._uncompressed_stream_offset = 0
 
         compressed_data_offset = 0
         compressed_data_size = self._file_object.get_size()
@@ -115,7 +115,7 @@ class CompressedStream(file_io.FileIO):
         """
 
         buffer_start_offset = (
-            self._uncompressed_stream_position - self._uncompressed_data_size
+            self._uncompressed_stream_offset - self._uncompressed_data_size
         )
         # If there is no decompressor or there was a backwards a new decompressor is
         # needed.
@@ -126,10 +126,10 @@ class CompressedStream(file_io.FileIO):
             self._uncompressed_data = b""
             self._uncompressed_data_size = 0
             self._uncompressed_data_offset = 0
-            self._uncompressed_stream_position = 0
+            self._uncompressed_stream_offset = 0
             buffer_start_offset = 0
 
-        while uncompressed_data_offset >= self._uncompressed_stream_position:
+        while uncompressed_data_offset >= self._uncompressed_stream_offset:
             read_count = self._ReadCompressedData(self._COMPRESSED_DATA_BUFFER_SIZE)
             if read_count == 0:
                 # End of the compressed stream before the target offset.
@@ -137,7 +137,7 @@ class CompressedStream(file_io.FileIO):
                 return
 
             buffer_start_offset = (
-                self._uncompressed_stream_position - self._uncompressed_data_size
+                self._uncompressed_stream_offset - self._uncompressed_data_size
             )
 
         self._uncompressed_data_offset = uncompressed_data_offset - buffer_start_offset
@@ -162,7 +162,7 @@ class CompressedStream(file_io.FileIO):
         )
         self._uncompressed_data_size = len(self._uncompressed_data)
 
-        self._uncompressed_stream_position += self._uncompressed_data_size
+        self._uncompressed_stream_offset += self._uncompressed_data_size
 
         return read_count
 

--- a/dfvfs/file_io/compressed_stream_io.py
+++ b/dfvfs/file_io/compressed_stream_io.py
@@ -7,6 +7,7 @@ from dfvfs.file_io import file_io
 from dfvfs.lib import errors
 from dfvfs.resolver import resolver
 
+
 class CompressedStream(file_io.FileIO):
     """File input/output (IO) object of a compressed stream."""
 
@@ -80,7 +81,7 @@ class CompressedStream(file_io.FileIO):
             uncompressed_stream_size += self._uncompressed_data_size
 
         return uncompressed_stream_size
-    
+
     def _Open(self):
         """Opens the file-like object.
 
@@ -107,13 +108,15 @@ class CompressedStream(file_io.FileIO):
         For forward seeks within an already initialized decompressor, this
         continues decompressing from the current position rather than rewinding
         and decompressing the entire stream.
-        
+
         Args:
           uncompressed_data_offset (int): uncompressed data offset.
         """
 
-        buffer_start_offset = self._uncompressed_stream_position - self._uncompressed_data_size
-        
+        buffer_start_offset = (
+            self._uncompressed_stream_position - self._uncompressed_data_size
+        )
+
         # if we don't have a decompressor we need one, or if we need to seek backwards
         # we need a new decompressor
         if self._decompressor is None or uncompressed_data_offset < buffer_start_offset:
@@ -133,10 +136,12 @@ class CompressedStream(file_io.FileIO):
                 # End of the compressed stream before the target offset.
                 self._uncompressed_data_offset = self._uncompressed_data_size
                 return
-            buffer_start_offset = self._uncompressed_stream_position - self._uncompressed_data_size
+            buffer_start_offset = (
+                self._uncompressed_stream_position - self._uncompressed_data_size
+            )
 
         self._uncompressed_data_offset = uncompressed_data_offset - buffer_start_offset
-        
+
     def _ReadCompressedData(self, read_size):
         """Reads compressed data from the file-like object.
 

--- a/dfvfs/file_io/compressed_stream_io.py
+++ b/dfvfs/file_io/compressed_stream_io.py
@@ -7,7 +7,6 @@ from dfvfs.file_io import file_io
 from dfvfs.lib import errors
 from dfvfs.resolver import resolver
 
-
 class CompressedStream(file_io.FileIO):
     """File input/output (IO) object of a compressed stream."""
 
@@ -62,9 +61,12 @@ class CompressedStream(file_io.FileIO):
           int: uncompressed stream size.
         """
         self._file_object.seek(0, os.SEEK_SET)
-
         self._decompressor = self._GetDecompressor()
+        self._compressed_data = b""
         self._uncompressed_data = b""
+        self._uncompressed_data_size = 0
+        self._uncompressed_data_offset = 0
+        self._uncompressed_stream_position = 0
 
         compressed_data_offset = 0
         compressed_data_size = self._file_object.get_size()
@@ -74,12 +76,11 @@ class CompressedStream(file_io.FileIO):
             read_count = self._ReadCompressedData(self._COMPRESSED_DATA_BUFFER_SIZE)
             if read_count == 0:
                 break
-
             compressed_data_offset += read_count
             uncompressed_stream_size += self._uncompressed_data_size
 
         return uncompressed_stream_size
-
+    
     def _Open(self):
         """Opens the file-like object.
 
@@ -103,30 +104,39 @@ class CompressedStream(file_io.FileIO):
     def _AlignUncompressedDataOffset(self, uncompressed_data_offset):
         """Aligns the compressed file with the uncompressed data offset.
 
+        For forward seeks within an already initialized decompressor, this
+        continues decompressing from the current position rather than rewinding
+        and decompressing the entire stream.
+        
         Args:
           uncompressed_data_offset (int): uncompressed data offset.
         """
-        self._file_object.seek(0, os.SEEK_SET)
 
-        self._decompressor = self._GetDecompressor()
-        self._uncompressed_data = b""
+        buffer_start_offset = self._uncompressed_stream_position - self._uncompressed_data_size
+        
+        # if we don't have a decompressor we need one, or if we need to seek backwards
+        # we need a new decompressor
+        if self._decompressor is None or uncompressed_data_offset < buffer_start_offset:
+            self._file_object.seek(0, os.SEEK_SET)
+            self._decompressor = self._GetDecompressor()
+            self._compressed_data = b""
+            self._uncompressed_data = b""
+            self._uncompressed_data_size = 0
+            self._uncompressed_data_offset = 0
+            self._uncompressed_stream_position = 0
+            buffer_start_offset = 0
 
-        compressed_data_offset = 0
-        compressed_data_size = self._file_object.get_size()
-
-        while compressed_data_offset < compressed_data_size:
+        # decompress forward
+        while uncompressed_data_offset >= self._uncompressed_stream_position:
             read_count = self._ReadCompressedData(self._COMPRESSED_DATA_BUFFER_SIZE)
             if read_count == 0:
-                break
+                # End of the compressed stream before the target offset.
+                self._uncompressed_data_offset = self._uncompressed_data_size
+                return
+            buffer_start_offset = self._uncompressed_stream_position - self._uncompressed_data_size
 
-            compressed_data_offset += read_count
-
-            if uncompressed_data_offset < self._uncompressed_data_size:
-                self._uncompressed_data_offset = uncompressed_data_offset
-                break
-
-            uncompressed_data_offset -= self._uncompressed_data_size
-
+        self._uncompressed_data_offset = uncompressed_data_offset - buffer_start_offset
+        
     def _ReadCompressedData(self, read_size):
         """Reads compressed data from the file-like object.
 
@@ -147,6 +157,8 @@ class CompressedStream(file_io.FileIO):
         )
 
         self._uncompressed_data_size = len(self._uncompressed_data)
+
+        self._uncompressed_stream_position += self._uncompressed_data_size
 
         return read_count
 

--- a/dfvfs/file_io/compressed_stream_io.py
+++ b/dfvfs/file_io/compressed_stream_io.py
@@ -32,6 +32,7 @@ class CompressedStream(file_io.FileIO):
         self._uncompressed_data_offset = 0
         self._uncompressed_data_size = 0
         self._uncompressed_stream_size = None
+        self._uncompressed_stream_position = 0
 
     def _Close(self):
         """Closes the file-like object.

--- a/tests/file_io/compressed_stream_io.py
+++ b/tests/file_io/compressed_stream_io.py
@@ -3,6 +3,9 @@
 
 import os
 import unittest
+import lzma
+import tempfile
+import time
 
 from dfvfs.file_io import compressed_stream_io
 from dfvfs.lib import definitions
@@ -10,6 +13,7 @@ from dfvfs.path import factory as path_spec_factory
 from dfvfs.resolver import context
 
 from tests.file_io import test_lib
+from tests import test_lib as shared_test_lib
 
 
 class BZIP2CompressedStreamTest(test_lib.SylogTestCase):
@@ -291,6 +295,75 @@ class ZlibCompressedStreamTest(test_lib.SylogTestCase):
 
         self._TestReadFileObject(file_object)
 
+class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
+    """Regression test for forward seeks rewinding the decompressor."""
 
+    _STREAM_SIZE = 16 * 1024 * 1024     # 16 MiB
+    _NUM_SEEKS = 5000                   # forward seeks issued
+    _MAX_ELAPSED = 5.0                  # seconds before declaring failure
+
+    def setUp(self):
+        self._resolver_context = context.Context()
+
+    def tearDown(self):
+        self._resolver_context.Empty()
+
+    def testForwardSeekDoesNotRewind(self):
+        """Forward seeks must take near constant time regardless of stream size.
+
+        Issues many small read+forward-seek pairs and bails out if the
+        loop wall time crosses a generous threshold — failing any
+        implementation that restarts decompression on each realignment
+        and therefore scales as O(N * stream_size) instead of
+        O(N + stream_size).
+
+        Pseudo-random data keeps decompression speed bounded by
+        liblzma's per-byte literal cost rather than the near-memcpy
+        speed of repeating patterns or an empty file. Without this,
+        quadratic/polynomial behavior can hide on fast hardware.
+        """
+
+        import random
+        rng = random.Random(0)
+        data = rng.randbytes(self._STREAM_SIZE)
+        compressed = lzma.compress(data, format=lzma.FORMAT_XZ, preset=0)
+
+        temp = tempfile.NamedTemporaryFile(suffix='.xz', delete=False)
+        temp.write(compressed)
+        temp.close()
+        self.addCleanup(os.unlink, temp.name)
+
+        os_path_spec = path_spec_factory.Factory.NewPathSpec(
+            definitions.TYPE_INDICATOR_OS, location=temp.name)
+        path_spec = path_spec_factory.Factory.NewPathSpec(
+            definitions.TYPE_INDICATOR_COMPRESSED_STREAM,
+            compression_method=definitions.COMPRESSION_METHOD_XZ,
+            parent=os_path_spec)
+
+        file_object = compressed_stream_io.CompressedStream(
+            self._resolver_context, path_spec)
+        file_object.Open()
+        try:
+            step = (self._STREAM_SIZE - 32) // self._NUM_SEEKS
+            start = time.monotonic()
+            for i in range(self._NUM_SEEKS):
+                offset = i * step
+                file_object.seek(offset, os.SEEK_SET)
+
+                self.assertEqual(
+                    file_object.read(16), data[offset:offset + 16])
+                elapsed = time.monotonic() - start
+                if elapsed > self._MAX_ELAPSED:
+                    self.fail(
+                        f'After {i + 1} forward seeks of a '
+                        f'{self._STREAM_SIZE >> 20} MiB stream the loop '
+                        f'has run for {elapsed:.2f}s '
+                        f'(>{self._MAX_ELAPSED:.0f}s); forward seeks are '
+                        f'scaling with stream size rather than completing '
+                        f'in constant time.')                    
+        finally:
+            file_object.close()
+            
+            
 if __name__ == "__main__":
     unittest.main()

--- a/tests/file_io/compressed_stream_io.py
+++ b/tests/file_io/compressed_stream_io.py
@@ -295,12 +295,13 @@ class ZlibCompressedStreamTest(test_lib.SylogTestCase):
 
         self._TestReadFileObject(file_object)
 
+
 class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
     """Regression test for forward seeks rewinding the decompressor."""
 
-    _STREAM_SIZE = 16 * 1024 * 1024     # 16 MiB
-    _NUM_SEEKS = 5000                   # forward seeks issued
-    _MAX_ELAPSED = 5.0                  # seconds before declaring failure
+    _STREAM_SIZE = 16 * 1024 * 1024  # 16 MiB
+    _NUM_SEEKS = 5000  # forward seeks issued
+    _MAX_ELAPSED = 5.0  # seconds before declaring failure
 
     def setUp(self):
         self._resolver_context = context.Context()
@@ -324,24 +325,28 @@ class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
         """
 
         import random
+
         rng = random.Random(0)
         data = rng.randbytes(self._STREAM_SIZE)
         compressed = lzma.compress(data, format=lzma.FORMAT_XZ, preset=0)
 
-        temp = tempfile.NamedTemporaryFile(suffix='.xz', delete=False)
+        temp = tempfile.NamedTemporaryFile(suffix=".xz", delete=False)
         temp.write(compressed)
         temp.close()
         self.addCleanup(os.unlink, temp.name)
 
         os_path_spec = path_spec_factory.Factory.NewPathSpec(
-            definitions.TYPE_INDICATOR_OS, location=temp.name)
+            definitions.TYPE_INDICATOR_OS, location=temp.name
+        )
         path_spec = path_spec_factory.Factory.NewPathSpec(
             definitions.TYPE_INDICATOR_COMPRESSED_STREAM,
             compression_method=definitions.COMPRESSION_METHOD_XZ,
-            parent=os_path_spec)
+            parent=os_path_spec,
+        )
 
         file_object = compressed_stream_io.CompressedStream(
-            self._resolver_context, path_spec)
+            self._resolver_context, path_spec
+        )
         file_object.Open()
         try:
             step = (self._STREAM_SIZE - 32) // self._NUM_SEEKS
@@ -350,20 +355,20 @@ class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
                 offset = i * step
                 file_object.seek(offset, os.SEEK_SET)
 
-                self.assertEqual(
-                    file_object.read(16), data[offset:offset + 16])
+                self.assertEqual(file_object.read(16), data[offset : offset + 16])
                 elapsed = time.monotonic() - start
                 if elapsed > self._MAX_ELAPSED:
                     self.fail(
-                        f'After {i + 1} forward seeks of a '
-                        f'{self._STREAM_SIZE >> 20} MiB stream the loop '
-                        f'has run for {elapsed:.2f}s '
-                        f'(>{self._MAX_ELAPSED:.0f}s); forward seeks are '
-                        f'scaling with stream size rather than completing '
-                        f'in constant time.')                    
+                        f"After {i + 1} forward seeks of a "
+                        f"{self._STREAM_SIZE >> 20} MiB stream the loop "
+                        f"has run for {elapsed:.2f}s "
+                        f"(>{self._MAX_ELAPSED:.0f}s); forward seeks are "
+                        f"scaling with stream size rather than completing "
+                        f"in constant time."
+                    )
         finally:
             file_object.close()
-            
-            
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/file_io/compressed_stream_io.py
+++ b/tests/file_io/compressed_stream_io.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Tests for the compressed stream file-like object."""
 
-import os
-import unittest
 import lzma
+import os
+import random
 import tempfile
 import time
-import random
+import unittest
 
 from dfvfs.file_io import compressed_stream_io
 from dfvfs.lib import definitions

--- a/tests/file_io/compressed_stream_io.py
+++ b/tests/file_io/compressed_stream_io.py
@@ -6,6 +6,7 @@ import unittest
 import lzma
 import tempfile
 import time
+import random
 
 from dfvfs.file_io import compressed_stream_io
 from dfvfs.lib import definitions
@@ -323,8 +324,6 @@ class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
         speed of repeating patterns or an empty file. Without this,
         quadratic/polynomial behavior can hide on fast hardware.
         """
-
-        import random
 
         rng = random.Random(0)
         data = rng.randbytes(self._STREAM_SIZE)

--- a/tests/file_io/compressed_stream_io.py
+++ b/tests/file_io/compressed_stream_io.py
@@ -329,24 +329,24 @@ class CompressedStreamForwardSeekTest(shared_test_lib.BaseTestCase):
         data = rng.randbytes(self._STREAM_SIZE)
         compressed = lzma.compress(data, format=lzma.FORMAT_XZ, preset=0)
 
-        temp = tempfile.NamedTemporaryFile(suffix=".xz", delete=False)
-        temp.write(compressed)
-        temp.close()
-        self.addCleanup(os.unlink, temp.name)
+        with tempfile.NamedTemporaryFile(suffix=".xz", delete=False) as temp:
+            temp.write(compressed)
+            temp.close()
+            self.addCleanup(os.unlink, temp.name)
 
-        os_path_spec = path_spec_factory.Factory.NewPathSpec(
-            definitions.TYPE_INDICATOR_OS, location=temp.name
-        )
-        path_spec = path_spec_factory.Factory.NewPathSpec(
-            definitions.TYPE_INDICATOR_COMPRESSED_STREAM,
-            compression_method=definitions.COMPRESSION_METHOD_XZ,
-            parent=os_path_spec,
-        )
+            os_path_spec = path_spec_factory.Factory.NewPathSpec(
+                definitions.TYPE_INDICATOR_OS, location=temp.name
+            )
+            path_spec = path_spec_factory.Factory.NewPathSpec(
+                definitions.TYPE_INDICATOR_COMPRESSED_STREAM,
+                compression_method=definitions.COMPRESSION_METHOD_XZ,
+                parent=os_path_spec,
+            )
 
-        file_object = compressed_stream_io.CompressedStream(
-            self._resolver_context, path_spec
-        )
-        file_object.Open()
+            file_object = compressed_stream_io.CompressedStream(
+                self._resolver_context, path_spec
+            )
+            file_object.Open()
         try:
             step = (self._STREAM_SIZE - 32) // self._NUM_SEEKS
             start = time.monotonic()


### PR DESCRIPTION
The `compressed_stream_io.py` discarded the uncompressor on forward seeks, making it really slow to access the stream if the use pattern consisted of a large number of (small) forward seeks. I found this bug by investigating why log2timeline/plaso failed on a stuck worker that attempted to analyze a fairly large xz compressed tarball -- enumerating the tar contents thrashed the CompressedStream because it initialized a new decompressor and decompressed the entire stream on every forward seek.

The fix makes the CompressedStream retain the decompressor and when initialized, only discard it when seeking backwards, as compressed streams generally cannot be seeked backwards. Prior to the fix, small forward seeks caused the decompressor be initialized and decompress the entire stream up to the new seek position.

I included a test case that checks that 5000 forward seeks on a large xz-compressed stream of random bytes happens reasonably fast. (The compressed data shouldn't be a repeated pattern as that compresses too well, causing the test not to fail on an unfixed CompressedStream implementation)